### PR TITLE
Update dotsnapshot formula to v1.4.2 with real checksums

### DIFF
--- a/Formula/dotsnapshot.rb
+++ b/Formula/dotsnapshot.rb
@@ -1,21 +1,21 @@
 class Dotsnapshot < Formula
   desc "A CLI utility to create snapshots of dotfiles and configuration"
   homepage "https://github.com/tomerlichtash/dotsnapshot"
-  version "1.2.0"
+  version "1.4.2"
   
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/tomerlichtash/dotsnapshot/releases/download/v1.2.0/dotsnapshot-macos-arm64.tar.gz"
-      sha256 "aa506a303f3eee70e8eb15253f3acea87c6f653216ede98eef8ef4d7eb5ee66f"
+      url "https://github.com/tomerlichtash/dotsnapshot/releases/download/v1.4.2/dotsnapshot-macos-arm64.tar.gz"
+      sha256 "c880466b2cad2af96f452c57fefa8e5f60936dd21e683f9bb0db62887e134c0b"
     else
-      url "https://github.com/tomerlichtash/dotsnapshot/releases/download/v1.2.0/dotsnapshot-macos-x86_64.tar.gz"
-      sha256 "REPLACE_WITH_ACTUAL_SHA256_FOR_X86_64"
+      url "https://github.com/tomerlichtash/dotsnapshot/releases/download/v1.4.2/dotsnapshot-macos-x86_64.tar.gz"
+      sha256 "313adfb48ffea49a7e94bb82a254b43fc5e1a95d27380b23f1b2f16adfce85ad"
     end
   end
 
   on_linux do
-    url "https://github.com/tomerlichtash/dotsnapshot/releases/download/v1.2.0/dotsnapshot-linux-x86_64.tar.gz"
-    sha256 "REPLACE_WITH_ACTUAL_SHA256_FOR_LINUX"
+    url "https://github.com/tomerlichtash/dotsnapshot/releases/download/v1.4.2/dotsnapshot-linux-x86_64.tar.gz"
+    sha256 "75f62591596a8950b4e7fa5beb5243c1ac0a89199969d2d2283e5673b6f8c846"
   end
 
   depends_on "rust" => :build
@@ -33,11 +33,11 @@ class Dotsnapshot < Formula
 
   test do
     # Test version command
-    assert_match "dotsnapshot 1.2.0", shell_output("#{bin}/dotsnapshot --version")
+    assert_match "dotsnapshot 1.4.2", shell_output("#{bin}/dotsnapshot --version")
     
     # Test info command
     output = shell_output("#{bin}/dotsnapshot --info")
-    assert_match "dotsnapshot v1.2.0", output
+    assert_match "dotsnapshot v1.4.2", output
     assert_match "A CLI utility to create snapshots of dotfiles and configuration", output
     
     # Test list command


### PR DESCRIPTION
## Summary
- Update dotsnapshot formula from v1.2.0 to v1.4.2
- Replace placeholder checksums with real SHA256 values for all platforms
- Update test assertions to match new version

## Changes
- Version: 1.2.0 → 1.4.2
- URLs: Updated to point to v1.4.2 release assets
- SHA256 checksums for all platforms:
  - macOS ARM64: `c880466b2cad2af96f452c57fefa8e5f60936dd21e683f9bb0db62887e134c0b`
  - macOS x86_64: `313adfb48ffea49a7e94bb82a254b43fc5e1a95d27380b23f1b2f16adfce85ad`
  - Linux x86_64: `75f62591596a8950b4e7fa5beb5243c1ac0a89199969d2d2283e5673b6f8c846`

## Test plan
- [ ] Verify formula installs correctly on macOS ARM64
- [ ] Run `brew test dotsnapshot` to validate functionality
- [ ] Test on other platforms if available

Addresses #3